### PR TITLE
meaningfulweb updates

### DIFF
--- a/meaningfulweb-core/pom.xml
+++ b/meaningfulweb-core/pom.xml
@@ -74,18 +74,16 @@
 		<artifactId>boilerpipe</artifactId>
 		<version>1.1.0</version>
 	</dependency>
-	<dependency>
-       <groupId>nekohtml</groupId>
-       <artifactId>nekohtml</artifactId>
-       <version>1.9.13</version>
+    <dependency>
+        <groupId>net.sourceforge.nekohtml</groupId>
+        <artifactId>nekohtml</artifactId>
+        <version>1.9.17</version>
     </dependency>
-	
 	<dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>meaningfulweb-opengraph</artifactId>
       <version>${project.version}</version>
     </dependency>
-
 	<dependency>
 	    <groupId>org.apache.tika</groupId>
 	    <artifactId>tika-core</artifactId>
@@ -161,13 +159,13 @@
       <version>1.6.4</version>
     </dependency>
 
-    <!-- Html Cleaner -->    
+    <!-- Html Cleaner -->
     <dependency>
-      <groupId>org.htmlcleaner</groupId>
-      <artifactId>htmlcleaner</artifactId>
-      <version>2.2</version>
+        <groupId>net.sourceforge.htmlcleaner</groupId>
+        <artifactId>htmlcleaner</artifactId>
+        <version>2.2.1</version>
     </dependency>
-    
+
     <!-- XML and XPath Engine 
     <dependency>
       <groupId>xerces</groupId>


### PR DESCRIPTION
John,

I'm working on a project that could leverage the feature provided in your library.  After cloning the repository, I made a small build enhancement that fixed the groupId of nekohtml and htmlcleaner so users don't need to run bin/mvn-install.sh anymore.  I can remove lib and bin directory in my subsequent pull request.  Just want to send this one off first to get started.

Thanks,
calvin
